### PR TITLE
fix: copyAsset function for Windows

### DIFF
--- a/src/Commands/AssetsCommand.php
+++ b/src/Commands/AssetsCommand.php
@@ -68,6 +68,10 @@ class AssetsCommand extends Command
                 ->beforeLast(DIRECTORY_SEPARATOR),
         );
 
+        if(DIRECTORY_SEPARATOR === '\\') {
+            $filesystem->makeDirectory(dirname($to), 0755, true, true);
+        }
+
         $filesystem->copy($from, $to);
 
         $this->publishedAssets[] = $to;


### PR DESCRIPTION
Simple fix to make the install commands work on Windows