### PR TITLE
added group option from sortablejs

### DIFF
--- a/resources/js/sortable.js
+++ b/resources/js/sortable.js
@@ -11,6 +11,7 @@ export default (Alpine) => {
         }
 
         el.sortable = Sortable.create(el, {
+            group: el.getAttribute('x-sortable-group'),
             draggable: '[x-sortable-item]',
             handle: '[x-sortable-handle]',
             dataIdAttr: 'x-sortable-item',


### PR DESCRIPTION
This option would give the possibilty to drag items from/to mutliple or nested lists.

```html
List 1
<div x-data="{}"
     x-sortable
     x-sortable-group="same"
>
```

```html
List 2
<div x-data="{}"
     x-sortable
     x-sortable-group="same"
>
```